### PR TITLE
Refactor main.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ dist/
 # JetBrains IDE
 .idea/
 
+# VSCode IDE
+.vscode/
+
 # Unit test reports
 TEST*.xml
 
@@ -52,3 +55,7 @@ Thumbs.db
 db.sqlite
 .*.swp
 __pycache__
+
+# virtual env
+.env/
+.venv/

--- a/main.py
+++ b/main.py
@@ -540,7 +540,6 @@ def main(pm_enum, pm_name, pkg_name):
 		return
 
 	pm_proxy = get_pm_proxy(pm_enum, cache_dir=None, isolate_pkg_info=False)
-	assert pm_proxy, "%s not supported" % (pm_name)
 
 	ver_str = None
 	if '==' in pkg_name:

--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ def alert_user(alert_type, threat_model, reason, risks):
 			risks[risk_cat].append(item)
 	return risks
 
-def analyze_release_history(pm_proxy, pkg_name, ver_str, pkg_info=None, risks={}, report={}):
+def analyze_release_history(pm_proxy, pkg_name, pkg_info, risks, report):
 	try:
 		print("\t[+] Checking release history...", end='', flush=True)
 
@@ -63,7 +63,7 @@ def analyze_release_history(pm_proxy, pkg_name, ver_str, pkg_info=None, risks={}
 	finally:
 		return risks, report
 
-def analyze_release_time(pm_proxy, pkg_name, ver_str, pkg_info=None, risks={}, report={}):
+def analyze_release_time(pm_proxy, pkg_name, ver_str, pkg_info, risks, report):
 	try:
 		print("\t[+] Checking release time gap...", end='', flush=True)
 
@@ -86,7 +86,7 @@ def analyze_release_time(pm_proxy, pkg_name, ver_str, pkg_info=None, risks={}, r
 	finally:
 		return risks, report
 
-def analyze_pkg_descr(pm_proxy, pkg_name, ver_str, pkg_info=None, ver_info=None, risks={}, report={}):
+def analyze_pkg_descr(pm_proxy, pkg_name, ver_str, pkg_info, risks, report):
 	try:
 		print("\t[+] Checking package description...", end='', flush=True)
 		descr = pm_proxy.get_description(pkg_name, ver_str=ver_str, pkg_info=pkg_info)
@@ -102,7 +102,7 @@ def analyze_pkg_descr(pm_proxy, pkg_name, ver_str, pkg_info=None, ver_info=None,
 	finally:
 		return risks, report
 
-def analyze_version(ver_info, risks={}, report={}):
+def analyze_version(ver_info, risks, report):
 	try:
 		print("[+] Checking version...", end='', flush=True)
 
@@ -129,7 +129,7 @@ def analyze_version(ver_info, risks={}, report={}):
 	finally:
 		return risks, report
 
-def analyze_cves(pm_name, pkg_name, ver_str, risks={}, report={}):
+def analyze_cves(pm_name, pkg_name, ver_str, risks, report):
 	try:
 		print("[+] Checking for CVEs...", end='', flush=True)
 		from osv import get_pkgver_vulns
@@ -148,7 +148,7 @@ def analyze_cves(pm_name, pkg_name, ver_str, risks={}, report={}):
 	finally:
 		return risks, report
 
-def analyze_deps(pm_proxy, pkg_name, ver_str, pkg_info=None, ver_info=None, risks={}, report={}):
+def analyze_deps(pm_proxy, pkg_name, ver_str, pkg_info, ver_info, risks, report):
 	try:
 		print("[+] Checking dependencies...", end='', flush=True)
 		deps = pm_proxy.get_dependencies(pkg_name, ver_str=ver_str, pkg_info=pkg_info, ver_info=ver_info)
@@ -164,7 +164,7 @@ def analyze_deps(pm_proxy, pkg_name, ver_str, pkg_info=None, ver_info=None, risk
 	finally:
 		return risks, report
 
-def analyze_downloads(pm_proxy, pkg_name, ver_str=None, pkg_info=None, risks={}, report={}):
+def analyze_downloads(pm_proxy, pkg_name, risks, report):
 	try:
 		print("[+] Checking downloads...", end='', flush=True)
 		ret = pm_proxy.get_downloads(pkg_name)
@@ -178,7 +178,7 @@ def analyze_downloads(pm_proxy, pkg_name, ver_str=None, pkg_info=None, risks={},
 	finally:
 		return risks, report
 
-def analyze_homepage(pm_proxy, pkg_name, ver_str=None, pkg_info=None, risks={}, report={}):
+def analyze_homepage(pm_proxy, pkg_name, ver_str, pkg_info, risks, report):
 	try:
 		print("[+] Checking homepage...", end='', flush=True)
 		url = pm_proxy.get_homepage(pkg_name, ver_str=ver_str, pkg_info=pkg_info)
@@ -212,7 +212,7 @@ def analyze_homepage(pm_proxy, pkg_name, ver_str=None, pkg_info=None, risks={}, 
 	finally:
 		return risks, report
 
-def analyze_repo_descr(pkg_name, ver_str=None, pkg_info=None, ver_info=None, risks={}, report={}):
+def analyze_repo_descr(risks, report):
 	try:
 		print("\t[+] Checking repo description...", end='', flush=True)
 		descr = report['repo']['description']
@@ -222,7 +222,7 @@ def analyze_repo_descr(pkg_name, ver_str=None, pkg_info=None, ver_info=None, ris
 	finally:
 		return risks, report
 
-def analyze_repo_data(pkg_name, ver_str=None, pkg_info=None, ver_info=None, risks={}, report={}):
+def analyze_repo_data(risks, report):
 	try:
 		repo_url = report['repo']['url']
 		print("\t[+] Checking repo data...", end='', flush=True)
@@ -276,7 +276,7 @@ def analyze_repo_data(pkg_name, ver_str=None, pkg_info=None, ver_info=None, risk
 	finally:
 		return risks, report
 
-def analyze_repo_activity(pkg_name, ver_str=None, pkg_info=None, ver_info=None, risks={}, report={}):
+def analyze_repo_activity(risks, report):
 	try:
 		repo_url = report['repo']['url']
 		print("\t[+] Checking repo activity...", end='', flush=True)
@@ -294,7 +294,7 @@ def analyze_repo_activity(pkg_name, ver_str=None, pkg_info=None, ver_info=None, 
 	finally:
 		return risks, report
 
-def analyze_repo_url(pm_proxy, pkg_name, ver_str=None, pkg_info=None, ver_info=None, risks={}, report={}):
+def analyze_repo_url(pm_proxy, pkg_name, ver_str, pkg_info, ver_info, risks, report):
 	try:
 		print("[+] Checking repo URL...", end='', flush=True)
 		popular_hosting_services = ['https://github.com/','https://gitlab.com/','git+https://github.com/','git://github.com/','https://bitbucket.com/']
@@ -333,7 +333,7 @@ def analyze_repo_url(pm_proxy, pkg_name, ver_str=None, pkg_info=None, ver_info=N
 	finally:
 		return risks, report
 
-def analyze_readme(pm_proxy, pkg_name, ver_str=None, pkg_info=None, risks={}, report={}):
+def analyze_readme(pm_proxy, pkg_name, ver_str, pkg_info, risks, report):
 	try:
 		print("[+] Checking readme...", end='', flush=True)
 		readme = pm_proxy.get_readme(pkg_name, ver_str=ver_str, pkg_info=pkg_info)
@@ -349,7 +349,7 @@ def analyze_readme(pm_proxy, pkg_name, ver_str=None, pkg_info=None, risks={}, re
 	finally:
 		return risks, report
 
-def analyze_author(pm_proxy, pkg_name, ver_str=None, pkg_info=None, ver_info=None, risks={}, report={}):
+def analyze_author(pm_proxy, pkg_name, ver_str, pkg_info, ver_info, risks, report):
 	try:
 		print("[+] Checking author...", end='', flush=True)
 
@@ -406,7 +406,7 @@ def analyze_author(pm_proxy, pkg_name, ver_str=None, pkg_info=None, ver_info=Non
 	finally:
 		return risks, report
 
-def analyze_composition(pm_name, pkg_name, ver_str, filepath, risks={}, report={}):
+def analyze_composition(pm_name, pkg_name, ver_str, filepath, risks, report):
 	try:
 		print("[+] Checking files/funcs...", end='', flush=True)
 
@@ -433,7 +433,7 @@ def analyze_composition(pm_name, pkg_name, ver_str, filepath, risks={}, report={
 	finally:
 		return risks, report
 
-def analyze_apis(pm_name, pkg_name, ver_str, filepath, risks={}, report={}):
+def analyze_apis(pm_name, pkg_name, ver_str, filepath, risks, report):
 	try:
 		print("[+] Analyzing code...", end='', flush=True)
 		if pm_name == 'pypi':
@@ -574,22 +574,22 @@ def main(pm_enum, pm_name, pkg_name):
 	report = {}
 
 	# analyze metadata
-	risks, report = analyze_pkg_descr(pm_proxy, pkg_name, ver_str, pkg_info=pkg_info, ver_info=ver_info, risks=risks, report=report)
-	risks, report = analyze_release_history(pm_proxy, pkg_name, ver_str, pkg_info=pkg_info, risks=risks, report=report)
-	risks, report = analyze_version(ver_info, risks=risks, report=report)
-	risks, report = analyze_release_time(pm_proxy, pkg_name, ver_str, pkg_info=pkg_info, risks=risks, report=report)
-	risks, report = analyze_author(pm_proxy, pkg_name, ver_str=ver_str, pkg_info=pkg_info, ver_info=ver_info, risks=risks, report=report)
-	risks, report = analyze_readme(pm_proxy, pkg_name, ver_str=ver_str, pkg_info=pkg_info, risks=risks, report=report)
-	risks, report = analyze_homepage(pm_proxy, pkg_name, ver_str=ver_str, pkg_info=pkg_info, risks=risks, report=report)
-	risks, report = analyze_downloads(pm_proxy, pkg_name, ver_str=ver_str, pkg_info=pkg_info, risks=risks, report=report)
-	risks, report = analyze_repo_url(pm_proxy, pkg_name, ver_str=ver_str, pkg_info=pkg_info, ver_info=ver_info, risks=risks, report=report)
+	risks, report = analyze_pkg_descr(pm_proxy, pkg_name, ver_str, pkg_info, risks, report)
+	risks, report = analyze_release_history(pm_proxy, pkg_name, pkg_info, risks, report)
+	risks, report = analyze_version(ver_info, risks, report)
+	risks, report = analyze_release_time(pm_proxy, pkg_name, ver_str, pkg_info, risks, report)
+	risks, report = analyze_author(pm_proxy, pkg_name, ver_str, pkg_info, ver_info, risks, report)
+	risks, report = analyze_readme(pm_proxy, pkg_name, ver_str, pkg_info, risks, report)
+	risks, report = analyze_homepage(pm_proxy, pkg_name, ver_str, pkg_info, risks, report)
+	risks, report = analyze_downloads(pm_proxy, pkg_name, risks, report)
+	risks, report = analyze_repo_url(pm_proxy, pkg_name, ver_str, pkg_info, ver_info, risks, report)
 	if 'repo' in report and 'url' in report['repo'] and report['repo']['url']:
-		risks, report = analyze_repo_data(pkg_name, ver_str=ver_str, pkg_info=pkg_info, ver_info=ver_info, risks=risks, report=report)
+		risks, report = analyze_repo_data(risks, report)
 		if 'description' in report['repo']:
-			risks, report = analyze_repo_descr(pkg_name, ver_str=ver_str, pkg_info=pkg_info, ver_info=ver_info, risks=risks, report=report)
-		risks, report = analyze_repo_activity(pkg_name, ver_str=ver_str, pkg_info=pkg_info, ver_info=ver_info, risks=risks, report=report)
-	risks, report = analyze_cves(pm_name, pkg_name, ver_str=ver_str, risks=risks, report=report)
-	risks, report = analyze_deps(pm_proxy, pkg_name, ver_str, pkg_info=pkg_info, ver_info=ver_info, risks=risks, report=report)
+			risks, report = analyze_repo_descr(risks, report)
+		risks, report = analyze_repo_activity(risks, report)
+	risks, report = analyze_cves(pm_name, pkg_name, ver_str, risks, report)
+	risks, report = analyze_deps(pm_proxy, pkg_name, ver_str, pkg_info, ver_info, risks, report)
 
 	# download package
 	try:
@@ -602,8 +602,8 @@ def main(pm_enum, pm_name, pkg_name):
 		print("FAILED [%s]" % (str(e)))
 
 	if filepath:
-		risks, report = analyze_apis(pm_name, pkg_name, ver_str, filepath, risks=risks, report=report)
-		risks, report = analyze_composition(pm_name, pkg_name, ver_str, filepath, risks=risks, report=report)
+		risks, report = analyze_apis(pm_name, pkg_name, ver_str, filepath, risks, report)
+		risks, report = analyze_composition(pm_name, pkg_name, ver_str, filepath, risks, report)
 
 	print("=============================================")
 	if not len(risks):
@@ -616,7 +616,7 @@ def main(pm_enum, pm_name, pkg_name):
 	write_json_to_file(filename, report, indent=4)
 	print("=> Complete report: %s" % (filename))
 
-	if pm_name.lower() == 'pypi':
+	if pm_enum == PackageManagerEnum.pypi:
 		print("=> View pre-vetted package report at https://packj.dev/package/PyPi/%s/%s" % (pkg_name, ver_str))
 
 def get_base_pkg_info():

--- a/main.py
+++ b/main.py
@@ -3,14 +3,13 @@
 from __future__ import print_function
 import sys
 import os
-import json
 import logging
 
 from util.net import __parse_url, download_file, check_site_exist, check_domain_popular
 from util.dates import datetime_delta
 from util.email_validity import check_email_address
 from util.files import write_json_to_file, read_from_csv
-from util.enum_util import PackageManagerEnum, LanguageEnum, DistanceAlgorithmEnum, TraceTypeEnum, DataTypeEnum
+from util.enum_util import PackageManagerEnum, LanguageEnum
 from util.formatting import human_format
 from util.repo import git_clone, replace_last
 
@@ -534,7 +533,6 @@ def analyze_apis(pm_name, pkg_name, ver_str, filepath, risks={}, report={}):
 		return risks, report
 
 def main(pm, pkg_name):
-	from static_util import astgen
 
 	try:
 		build_threat_model()

--- a/main.py
+++ b/main.py
@@ -313,21 +313,21 @@ def analyze_repo_activity(risks, report):
 def analyze_repo_url(pm_proxy, pkg_name, ver_str, pkg_info, ver_info, risks, report):
 	try:
 		print('[+] Checking repo URL...', end='', flush=True)
-		popular_hosting_services = [
+		popular_hosting_services = (
 			'https://github.com/',
 			'https://gitlab.com/',
 			'git+https://github.com/',
 			'git://github.com/',
 			'https://bitbucket.com/',
-		]
+		)
 		repo_url = pm_proxy.get_repo(pkg_name, ver_str=ver_str, pkg_info=pkg_info, ver_info=ver_info)
 		if not repo_url:
 			repo_url = pm_proxy.get_homepage(pkg_name, ver_str=ver_str, pkg_info=pkg_info)
-			if not repo_url or not repo_url.startswith(tuple(popular_hosting_services)):
+			if not repo_url or not repo_url.startswith(popular_hosting_services):
 				repo_url = None
 		if not repo_url:
 			repo_url = pm_proxy.get_download_url(pkg_name, ver_str=ver_str, pkg_info=pkg_info)
-			if not repo_url or not repo_url.startswith(tuple(popular_hosting_services)):
+			if not repo_url or not repo_url.startswith(popular_hosting_services):
 				repo_url = None
 		if repo_url:
 			if repo_url.startswith('git+https://'):
@@ -342,7 +342,7 @@ def analyze_repo_url(pm_proxy, pkg_name, ver_str, pkg_info, ver_info, risks, rep
 			reason = 'no source repo found'
 			alert_type = 'invalid or no source repo'
 			risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
-		elif not repo_url.startswith(tuple(popular_hosting_services)):
+		elif not repo_url.startswith(popular_hosting_services):
 			reason = f'invalid source repo {repo_url}'
 			alert_type = 'invalid or no source repo'
 			risks = alert_user(alert_type, THREAT_MODEL, reason, risks)

--- a/main.py
+++ b/main.py
@@ -28,7 +28,6 @@ if sys.version_info[0] != 3:
 THREAT_MODEL = {}
 
 def build_threat_model(filename='threats.csv'):
-	global THREAT_MODEL
 	for line in read_from_csv(filename, skip_header=True):
 		typ = line[0]
 		attr = line[1].strip('\n')

--- a/main.py
+++ b/main.py
@@ -22,10 +22,19 @@ from parse_repo import fetch_repo_data
 
 # sys.version_info[0] is the major version number. sys.version_info[1] is minor
 if sys.version_info[0] != 3:
-	print("\n*** WARNING *** Please use Python 3! Exiting.")
+	print('\n*** WARNING *** Please use Python 3! Exiting.')
 	exit(1)
 
 THREAT_MODEL = {}
+
+def msg_factory(fmt_str):
+	def run(content):
+		return fmt_str.format(content)
+	return run
+
+msg_fail = msg_factory('FAILED [{0}]')
+msg_ok = msg_factory('OK [{0}]')
+msg_alert = msg_factory('ALERT [{0}]')
 
 def build_threat_model(filename='threats.csv'):
 	for line in read_from_csv(filename, skip_header=True):
@@ -38,75 +47,76 @@ def alert_user(alert_type, threat_model, reason, risks):
 		risk_cat = threat_model[alert_type]
 		if risk_cat not in risks:
 			risks[risk_cat] = []
-		item = '%s: %s' % (alert_type, reason)
+		item = f'{alert_type}: {reason}'
 		if item not in risks[risk_cat]:
 			risks[risk_cat].append(item)
 	return risks
 
 def analyze_release_history(pm_proxy, pkg_name, pkg_info, risks, report):
 	try:
-		print("\t[+] Checking release history...", end='', flush=True)
+		print('\t[+] Checking release history...', end='', flush=True)
 
 		# get package release history
 		release_history = pm_proxy.get_release_history(pkg_name, pkg_info=pkg_info)
-		assert release_history, "no data!"
+		assert release_history, 'no data!'
 
 		if len(release_history) <= 2:
-			reason = 'only %s versions released' % (len(release_history))
+			reason = f'only {len(release_history)} versions released'
 			alert_type = 'few versions or releases'
 			risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
 
-		print("OK [%d version(s)]" % (len(release_history)))
+		print(msg_ok(f'{len(release_history)} version(s)'))
 		report['num_releases'] = len(release_history)
 	except Exception as e:
-		print("FAILED [%s]" % (str(e)))
+		print(msg_fail(str(e)))
 	finally:
 		return risks, report
 
 def analyze_release_time(pm_proxy, pkg_name, ver_str, pkg_info, risks, report):
 	try:
-		print("\t[+] Checking release time gap...", end='', flush=True)
+		print('\t[+] Checking release time gap...', end='', flush=True)
 
 		# get package release history
 		release_history = pm_proxy.get_release_history(pkg_name, pkg_info=pkg_info)
-		assert release_history, "no data!"
+		assert release_history, 'no data!'
 
 		days = release_history[ver_str]['days_since_last_release']
 
 		# check if the latest release is made after a long gap (indicative of package takeover)
+		release_info = f'{days} days since last release' if days else 'first release'
 		if days and days > 180:
-			reason = 'version released after %d days' % (days)
+			reason = f'version released after {days} days'
 			alert_type = 'version release after a long gap'
 			risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
-			print("ALERT [%s]" % ('%d days since last release' % (days) if days else 'first release'))
+			print(msg_alert(release_info))
 		else:
-			print("OK [%s]" % ('%d days since last release' % (days) if days else 'first release'))
+			print(msg_ok(release_info))
 	except Exception as e:
-		print("FAILED [%s]" % (str(e)))
+		print(msg_fail(str(e)))
 	finally:
 		return risks, report
 
 def analyze_pkg_descr(pm_proxy, pkg_name, ver_str, pkg_info, risks, report):
 	try:
-		print("\t[+] Checking package description...", end='', flush=True)
+		print('\t[+] Checking package description...', end='', flush=True)
 		descr = pm_proxy.get_description(pkg_name, ver_str=ver_str, pkg_info=pkg_info)
 		if not descr:
 			reason = 'no description'
 			alert_type = 'no description'
 			risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
-			print("ALERT [%s]" % (reason))
+			print(msg_alert(reason))
 		else:
-			print("OK [%s]" % (descr))
+			print(msg_ok(descr))
 	except Exception as e:
-		print("FAILED [%s]" % (str(e)))
+		print(msg_fail(str(e)))
 	finally:
 		return risks, report
 
 def analyze_version(ver_info, risks, report):
 	try:
-		print("[+] Checking version...", end='', flush=True)
+		print('[+] Checking version...', end='', flush=True)
 
-		assert ver_info, "no data!"
+		assert ver_info, 'no data!'
 
 		# check upload timestamp
 		try:
@@ -116,71 +126,73 @@ def analyze_version(ver_info, risks, report):
 			raise Exception('parse error')
 
 		# check if the latest release is too old (unmaintained package)
+		days_old =  f'{days} days old'
 		if not uploaded or days > 365:
-			reason = 'no release date' if not uploaded else '%d days old' % (days)
+			reason = 'no release date' if not uploaded else days_old
 			alert_type = 'old package'
 			risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
-			print("ALERT [%d days old]" % (days))
+			print(msg_alert(days_old))
 		else:
-			print("OK [%d days old]" % (days))
-		report["version"] = ver_info
+			print(msg_ok(days_old))
+		report['version'] = ver_info
 	except Exception as e:
-		print("FAILED [%s]" % (str(e)))
+		print(msg_fail(str(e)))
 	finally:
 		return risks, report
 
 def analyze_cves(pm_name, pkg_name, ver_str, risks, report):
 	try:
-		print("[+] Checking for CVEs...", end='', flush=True)
+		print('[+] Checking for CVEs...', end='', flush=True)
 		from osv import get_pkgver_vulns
 		vuln_list = get_pkgver_vulns(pm_name, pkg_name, ver_str)
 		if vuln_list:
-			alert_type = 'contains known vulnerablities (CVEs)'
-			reason = 'contains %s' % (','.join(vul['id'] for vul in vuln_list))
+			alert_type = 'contains known vulnerabilities (CVEs)'
+			vulnerabilities = ','.join(vul['id'] for vul in vuln_list)
+			reason = f'contains {vulnerabilities}'
 			risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
-			print("ALERT [%s found]" % (len(vuln_list)))
+			print(msg_alert(f'{len(vuln_list)} found'))
 		else:
 			vuln_list = []
-			print("OK [none found]")
-		report["vulnerabilities"] = vuln_list
+			print(msg_ok('none found'))
+		report['vulnerabilities'] = vuln_list
 	except Exception as e:
-		print("FAILED [%s]" % (str(e)))
+		print(msg_fail(str(e)))
 	finally:
 		return risks, report
 
 def analyze_deps(pm_proxy, pkg_name, ver_str, pkg_info, ver_info, risks, report):
 	try:
-		print("[+] Checking dependencies...", end='', flush=True)
+		print('[+] Checking dependencies...', end='', flush=True)
 		deps = pm_proxy.get_dependencies(pkg_name, ver_str=ver_str, pkg_info=pkg_info, ver_info=ver_info)
 		if deps and len(deps) > 10:
 			alert_type = 'too many dependencies'
-			reason = '%d found' % (len(deps))
+			reason = f'{len(deps)} found'
 			risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
-			print("ALERT [%s]" % (reason))
+			print(msg_alert(reason))
 		else:
-			print("OK [%s]" % ('%d direct' % (len(deps)) if deps else 'none found'))
+			print(msg_ok(f'{len(deps)} direct' if deps else 'none found'))
 	except Exception as e:
-		print("FAILED [%s]" % (str(e)))
+		print(msg_fail(str(e)))
 	finally:
 		return risks, report
 
 def analyze_downloads(pm_proxy, pkg_name, risks, report):
 	try:
-		print("[+] Checking downloads...", end='', flush=True)
+		print('[+] Checking downloads...', end='', flush=True)
 		ret = pm_proxy.get_downloads(pkg_name)
 		if ret < 1000:
-			reason = 'only %d weekly downloads' % (ret)
+			reason = f'only {ret} weekly downloads'
 			alert_type = 'few downloads'
 			risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
-		print("OK [%s weekly]" % (human_format(ret)))
+		print(msg_ok(f'{human_format(ret)} weekly)'))
 	except Exception as e:
-		print("FAILED [%s]" % (str(e)))
+		print(msg_fail(str(e)))
 	finally:
 		return risks, report
 
 def analyze_homepage(pm_proxy, pkg_name, ver_str, pkg_info, risks, report):
 	try:
-		print("[+] Checking homepage...", end='', flush=True)
+		print('[+] Checking homepage...', end='', flush=True)
 		url = pm_proxy.get_homepage(pkg_name, ver_str=ver_str, pkg_info=pkg_info)
 		if not url:
 			reason = 'no homepage'
@@ -205,27 +217,27 @@ def analyze_homepage(pm_proxy, pkg_name, ver_str, pkg_info, risks, report):
 				reason = 'invalid (popular) webpage'
 				alert_type = 'invalid or no homepage'
 				risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
-		print("OK [%s]" % (url))
-		report["homepage"] = url
+		print(msg_ok(url))
+		report['homepage'] = url
 	except Exception as e:
-		print("FAILED [%s]" % (str(e)))
+		print(msg_fail(str(e)))
 	finally:
 		return risks, report
 
 def analyze_repo_descr(risks, report):
 	try:
-		print("\t[+] Checking repo description...", end='', flush=True)
+		print('\t[+] Checking repo description...', end='', flush=True)
 		descr = report['repo']['description']
-		print("OK [%s]" % (descr))
+		print(msg_ok(descr))
 	except Exception as e:
-		print("FAILED [%s]" % (str(e)))
+		print(msg_fail(str(e)))
 	finally:
 		return risks, report
 
 def analyze_repo_data(risks, report):
 	try:
 		repo_url = report['repo']['url']
-		print("\t[+] Checking repo data...", end='', flush=True)
+		print('\t[+] Checking repo data...', end='', flush=True)
 		err, repo_data  = fetch_repo_data(repo_url)
 		assert repo_data, err
 
@@ -246,58 +258,64 @@ def analyze_repo_data(risks, report):
 
 		if num_forks and num_forks < 5:
 			alert_type = 'few source repo forks'
-			reason = 'only %d forks' % (num_forks)
+			reason = f'only {num_forks} forks'
 			risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
 
 		if num_stars and num_stars < 10:
 			alert_type = 'few source repo stars'
-			reason = 'only %d stars' % (num_stars)
+			reason = f'only {num_stars} stars'
 			risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
 
-		print("OK [stars: %d, forks: %d]" % (num_stars, num_forks))
+		print(msg_ok(f'stars: {num_stars}, forks: {num_forks}'))
 		report['repo'].update(repo_data)
 	except Exception as e:
-		print("FAILED [%s]" % (str(e)))
+		print(msg_fail(str(e)))
 
 	if not repo_data:
 		return risks, report
 
 	try:
-		print("\t[+] Checking if repo is a forked copy...", end='', flush=True)
+		print('\t[+] Checking if repo is a forked copy...', end='', flush=True)
 		if forked_from:
 			alert_type = 'source repo is a forked copy'
-			reason = 'forked from %s' % (forked_from)
+			reason = f'forked from {forked_from}'
 			risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
-			print("OK [forked from %s]" % forked_from)
+			print(msg_alert(reason))
 		else:
-			print("OK [original, not forked]")
+			print(msg_ok('original, not forked'))
 	except Exception as e:
-		print("FAILED [%s]" % (str(e)))
+		print(msg_fail(str(e)))
 	finally:
 		return risks, report
 
 def analyze_repo_activity(risks, report):
 	try:
 		repo_url = report['repo']['url']
-		print("\t[+] Checking repo activity...", end='', flush=True)
+		print('\t[+] Checking repo activity...', end='', flush=True)
 		reason, repo_data = git_clone(repo_url)
 		if reason:
 			alert_type = 'invalid or no source repo'
 			risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
-			print("ALERT [%s]" % (reason))
+			print(msg_alert(reason))
 		elif repo_data:
-			print("OK [commits: %d, contributors: %d, tags: %d]" % \
-				(repo_data['commits'], repo_data['contributors'], repo_data['tags']))
+			commits, contributors, tags = tuple(repo_data[k] for k in ('commits', 'contributors', 'tags'))
+			print(msg_ok(f'commits: {commits}, contributors: {contributors}, tags: {tags}'))
 			report['repo'].update(repo_data)
 	except Exception as e:
-		print("FAILED [%s]" % (str(e)))
+		print(msg_fail(str(e)))
 	finally:
 		return risks, report
 
 def analyze_repo_url(pm_proxy, pkg_name, ver_str, pkg_info, ver_info, risks, report):
 	try:
-		print("[+] Checking repo URL...", end='', flush=True)
-		popular_hosting_services = ['https://github.com/','https://gitlab.com/','git+https://github.com/','git://github.com/','https://bitbucket.com/']
+		print('[+] Checking repo URL...', end='', flush=True)
+		popular_hosting_services = [
+			'https://github.com/',
+			'https://gitlab.com/',
+			'git+https://github.com/',
+			'git://github.com/',
+			'https://bitbucket.com/',
+		]
 		repo_url = pm_proxy.get_repo(pkg_name, ver_str=ver_str, pkg_info=pkg_info, ver_info=ver_info)
 		if not repo_url:
 			repo_url = pm_proxy.get_homepage(pkg_name, ver_str=ver_str, pkg_info=pkg_info)
@@ -321,55 +339,55 @@ def analyze_repo_url(pm_proxy, pkg_name, ver_str, pkg_info, ver_info, risks, rep
 			alert_type = 'invalid or no source repo'
 			risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
 		elif not repo_url.startswith(tuple(popular_hosting_services)):
-			reason = 'invalid source repo %s' % (repo_url)
+			reason = f'invalid source repo {repo_url}'
 			alert_type = 'invalid or no source repo'
 			risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
-		print("OK [%s]" % (repo_url))
-		report["repo"] = {
-			"url" : repo_url,
+		print(msg_ok(repo_url))
+		report['repo'] = {
+			'url' : repo_url,
 		}
 	except Exception as e:
-		print("FAILED [%s]" % (str(e)))
+		print(msg_fail(str(e)))
 	finally:
 		return risks, report
 
 def analyze_readme(pm_proxy, pkg_name, ver_str, pkg_info, risks, report):
 	try:
-		print("[+] Checking readme...", end='', flush=True)
+		print('[+] Checking readme...', end='', flush=True)
 		readme = pm_proxy.get_readme(pkg_name, ver_str=ver_str, pkg_info=pkg_info)
 		if not readme or len(readme) < 100:
 			reason = 'no readme' if not readme else 'insufficient readme'
 			alert_type = 'no or insufficient readme'
 			risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
-			print("ALERT [%s]" % (reason))
+			print(msg_alert(reason))
 		else:
-			print("OK [%d bytes]" % (len(readme)))
+			print(msg_ok(f'{len(readme)} bytes'))
 	except Exception as e:
-		print("FAILED [%s]" % (str(e)))
+		print(msg_fail(str(e)))
 	finally:
 		return risks, report
 
 def analyze_author(pm_proxy, pkg_name, ver_str, pkg_info, ver_info, risks, report):
 	try:
-		print("[+] Checking author...", end='', flush=True)
+		print('[+] Checking author...', end='', flush=True)
 
 		# check author/maintainer email
 		author_info = pm_proxy.get_author(pkg_name, ver_str=ver_str, pkg_info=pkg_info, ver_info=ver_info)
-		assert author_info, "no data!"
+		assert author_info, 'no data!'
 
 		try:
 			email = author_info['email']
 		except KeyError:
 			email = None
 
-		report["author"] = author_info
-		print("OK [%s]" % (email))
+		report['author'] = author_info
+		print(msg_ok(email))
 	except Exception as e:
-		print("FAILED [%s]" % (str(e)))
+		print(msg_fail(str(e)))
 		return risks, report
 
 	try:
-		print("\t[+] Checking email/domain validity...", end='', flush=True)
+		print('\t[+] Checking email/domain validity...', end='', flush=True)
 		if email:
 			email = email.replace(' ','')
 			if isinstance(email, list):
@@ -384,58 +402,74 @@ def analyze_author(pm_proxy, pkg_name, ver_str, pkg_info, ver_info, risks, repor
 				else:
 					email_list = [email]
 			else:
-				raise Exception("parse error!")
+				raise Exception('parse error!')
 			for item in email_list:
 				try:
 					valid, valid_with_dns = check_email_address(item)
-				except Exception as ee:
-					logging.debug("Failed to parse email %s: %s" % (item, str(ee)))
+				except Exception as e:
+					logging.debug('Failed to parse email %s: %s', item, str(e))
 					valid = False
 				if not valid or not valid_with_dns:
 					break
 
-		if not email or not valid or not valid_with_dns:
+		def get_alert_reason():
+			if not email:
+				return 'no email'
+			if not valid:
+				return 'invalid author email'
+			if not valid_with_dns:
+				return 'expired author email domain'
+			return None
+
+		if reason := get_alert_reason():
 			alert_type = 'invalid or no author email (2FA not enabled)'
-			reason = 'no email' if not email else 'invalid author email' if not valid else 'expired author email domain'
 			risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
-			print("ALERT [%s]" % (reason))
+			print(msg_alert(reason))
 		else:
-			print("OK [%s]" % (email))
+			print(msg_ok(email))
 	except Exception as e:
-		print("FAILED [%s]" % (str(e)))
+		print(msg_fail(str(e)))
 	finally:
 		return risks, report
 
 def analyze_composition(pm_name, pkg_name, ver_str, filepath, risks, report):
 	try:
-		print("[+] Checking files/funcs...", end='', flush=True)
+		print('[+] Checking files/funcs...', end='', flush=True)
 
 		if pm_name == 'pypi':
 			language=LanguageEnum.python
 		elif pm_name == 'npm':
 			language=LanguageEnum.javascript
 		else:
-			raise Exception("Package manager %s not supported!")
+			raise Exception('Package manager %s not supported!')
 
-		num_files, lang_files, num_funcs, total_loc = parse_package_composition(pkg_name, ver_str, filepath + '.out.json')
+		num_files, lang_files, num_funcs, total_loc = parse_package_composition(
+			pkg_name,
+			ver_str,
+			filepath + '.out.json',
+		)
 		lang_file_ext = ','.join(Language2Extensions[language])
 
-		print("OK [%s files (%d %s), %s funcs, LoC: %s]" % \
-				(num_files, lang_files, lang_file_ext, num_funcs, human_format(total_loc)))
-		report["composition"] = {
-			"num_files" : num_files,
-			"num_funcs" : num_funcs,
-			"%s_files" % (lang_file_ext) : lang_files,
-			"Loc"		: total_loc,
+		content = (
+			f'{num_files} files ({lang_files} {lang_file_ext}), '
+			f'{num_funcs} funcs, '
+			f'LoC: {human_format(total_loc)}]'
+		)
+		print(msg_ok(content))
+		report['composition'] = {
+			'num_files' : num_files,
+			'num_funcs' : num_funcs,
+			f'{lang_file_ext}_files': lang_files,
+			'Loc'		: total_loc,
 		}
 	except Exception as e:
-		print("FAILED [%s]" % (str(e)))
+		print(msg_fail(str(e)))
 	finally:
 		return risks, report
 
 def analyze_apis(pm_name, pkg_name, ver_str, filepath, risks, report):
 	try:
-		print("[+] Analyzing code...", end='', flush=True)
+		print('[+] Analyzing code...', end='', flush=True)
 		if pm_name == 'pypi':
 			language=LanguageEnum.python
 			configpath = os.path.join('config','astgen_python_smt.config')
@@ -443,77 +477,77 @@ def analyze_apis(pm_name, pkg_name, ver_str, filepath, risks, report):
 			language=LanguageEnum.javascript
 			configpath = os.path.join('config','astgen_javascript_smt.config')
 		else:
-			raise Exception("Package manager %s not supported!")
+			raise Exception('Package manager %s not supported!')
 
 		static = get_static_proxy_for_language(language=language)
 		try:
 			static.astgen(inpath=filepath, outfile=filepath+'.out', root=None, configpath=configpath,
 				pkg_name=pkg_name, pkg_version=ver_str, evaluate_smt=False)
-		except Exception as ee:
-			logging.debug("Failed to parse: %s" % (str(ee)))
-			raise Exception("parse error")
+		except Exception as e:
+			logging.debug('Failed to parse: %s', str(e))
+			raise Exception('parse error')
 
-		assert os.path.exists(filepath+'.out'), "parse error!"
+		assert os.path.exists(filepath+'.out'), 'parse error!'
 
 		perms = parse_api_usage(pm_name, filepath+'.out')
 		if not perms:
-			print("OK [no perms found]")
+			print(msg_ok('no perms found'))
 			return risks, report
 
 		report_data = {}
 		perms_needed = set()
 		for p, usage in perms.items():
-			if p == "SOURCE_FILE":
+			if p == 'SOURCE_FILE':
 				alert_type = 'accesses files and dirs'
 				reason = 'reads files and dirs'
 				risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
 				perms_needed.add('file')
-			elif p == "SINK_FILE":
+			elif p == 'SINK_FILE':
 				alert_type = 'accesses files and dirs'
 				reason = 'writes to files and dirs'
 				risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
 				perms_needed.add('file')
-			elif p == "SINK_NETWORK":
+			elif p == 'SINK_NETWORK':
 				alert_type = 'communicates with external network'
 				reason = 'sends data over the network'
 				risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
 				perms_needed.add('network')
-			elif p == "SOURCE_NETWORK":
+			elif p == 'SOURCE_NETWORK':
 				alert_type = 'communicates with external network'
 				reason = 'fetches data over the network'
 				risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
 				perms_needed.add('network')
-			elif p == "SINK_CODE_GENERATION":
+			elif p == 'SINK_CODE_GENERATION':
 				alert_type = 'generates new code at runtime'
 				reason = 'generates new code at runtime'
 				risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
 				perms_needed.add('codegen')
-			elif p == "SINK_PROCESS_OPERATION":
+			elif p == 'SINK_PROCESS_OPERATION':
 				alert_type = 'forks or exits OS processes'
 				reason = 'performs a process operation'
 				risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
 				perms_needed.add('process')
-			elif p == "SOURCE_OBFUSCATION":
+			elif p == 'SOURCE_OBFUSCATION':
 				alert_type = 'accesses obfuscated (hidden) code'
 				reason = 'reads hidden code'
 				risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
 				perms_needed.add('decode')
-			elif p == "SOURCE_SETTINGS":
+			elif p == 'SOURCE_SETTINGS':
 				alert_type = 'accesses system/environment variables'
 				reason = 'reads system settings or environment variables'
 				risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
 				perms_needed.add('envvars')
-			elif p == "SINK_UNCLASSIFIED":
+			elif p == 'SINK_UNCLASSIFIED':
 				alert_type = 'changes system/environment variables'
 				reason = 'modifies system settings or environment variables'
 				risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
 				perms_needed.add('envvars')
-			elif p == "SOURCE_ACCOUNT":
+			elif p == 'SOURCE_ACCOUNT':
 				alert_type = 'changes system/environment variables'
 				reason = 'modifies system settings or environment variables'
 				risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
 				perms_needed.add('envvars')
-			elif p == "SOURCE_USER_INPUT":
+			elif p == 'SOURCE_USER_INPUT':
 				alert_type = 'reads user input'
 				reason = 'reads user input'
 				risks = alert_user(alert_type, THREAT_MODEL, reason, risks)
@@ -524,10 +558,10 @@ def analyze_apis(pm_name, pkg_name, ver_str, filepath, risks, report):
 			else:
 				report_data[reason] += usage
 
-		print("ALERT [needs %d perms: %s]" % (len(perms_needed), ','.join(perms_needed)))
-		report["permissions"] = report_data
+		print(msg_alert(f'needs {len(perms_needed)} perms: {",".join(perms_needed)}]'))
+		report['permissions'] = report_data
 	except Exception as e:
-		print("FAILED [%s]" % (str(e)))
+		print(msg_fail(str(e)))
 	finally:
 		return risks, report
 
@@ -536,7 +570,7 @@ def main(pm_enum, pm_name, pkg_name):
 	try:
 		build_threat_model()
 	except Exception as e:
-		logging.debug("Failed to build threat model: %s!" % (str(e)))
+		logging.debug('Failed to build threat model: %s!', str(e))
 		return
 
 	pm_proxy = get_pm_proxy(pm_enum, cache_dir=None, isolate_pkg_info=False)
@@ -547,9 +581,9 @@ def main(pm_enum, pm_name, pkg_name):
 
 	# get version metadata
 	try:
-		print("[+] Fetching '%s' from %s..." % (pkg_name, pm_name), end='', flush=True)
+		print(f"[+] Fetching '{pkg_name}' from {pm_name}...", end='', flush=True)
 		pkg_info = pm_proxy.get_metadata(pkg_name=pkg_name, pkg_version=ver_str)
-		assert pkg_info, "package not found!"
+		assert pkg_info, 'package not found!'
 
 		#print(json.dumps(pkg_info, indent=4))
 		try:
@@ -558,15 +592,15 @@ def main(pm_enum, pm_name, pkg_name):
 			pass
 
 		ver_info = pm_proxy.get_version(pkg_name, ver_str=ver_str, pkg_info=pkg_info)
-		assert ver_info, "No version info!"
+		assert ver_info, 'No version info!'
 
 		#print(json.dumps(ver_info, indent=4))
 		if not ver_str:
 			ver_str = ver_info['tag']
 
-		print("OK [ver %s]" % (ver_str))
+		print(msg_ok(f'ver {ver_str}'))
 	except Exception as e:
-		print("FAILED [%s]" % (str(e)))
+		print(msg_fail(str(e)))
 		exit(1)
 
 	risks = {}
@@ -592,44 +626,51 @@ def main(pm_enum, pm_name, pkg_name):
 
 	# download package
 	try:
-		print("[+] Downloading package '%s' (ver %s) from %s..." % (pkg_name, ver_str, pm_name), end='', flush=True)
+		print(
+			f"[+] Downloading package '{pkg_name}' (ver {ver_str}) from {pm_name}...",
+			end='',
+			flush=True
+		)
 		filepath, size = download_file(ver_info['url'])
-		print("OK [%0.2f KB]" % (float(size)/1024))
+		print(msg_ok(f'{float(size)/1024:.2f} KB'))
 	except KeyError:
-		print("FAILED [URL missing]")
+		print(msg_fail('URL missing'))
 	except Exception as e:
-		print("FAILED [%s]" % (str(e)))
+		print(msg_fail(str(e)))
 
 	if filepath:
 		risks, report = analyze_apis(pm_name, pkg_name, ver_str, filepath, risks, report)
 		risks, report = analyze_composition(pm_name, pkg_name, ver_str, filepath, risks, report)
 
-	print("=============================================")
-	if not len(risks):
-		print("[+] No risks found!")
-		report["risks"] = None
+	print('=============================================')
+	if not risks:
+		print('[+] No risks found!')
+		report['risks'] = None
 	else:
-		print("[+] %d risk(s) found, package is %s!" % (sum(len(v) for v in risks.values()), ', '.join(risks.keys())))
-		report["risks"] = risks
-	filename = "%s-%s-%s.json" % (pm_name, pkg_name, ver_str)
+		print(
+			f'[+] {sum(len(v) for v in risks.values())} risk(s) found, '
+			f'package is {", ".join(risks.keys())}!'
+		)
+		report['risks'] = risks
+	filename = f'{pm_name}-{pkg_name}-{ver_str}.json'
 	write_json_to_file(filename, report, indent=4)
-	print("=> Complete report: %s" % (filename))
+	print(f'=> Complete report: {filename}')
 
 	if pm_enum == PackageManagerEnum.pypi:
-		print("=> View pre-vetted package report at https://packj.dev/package/PyPi/%s/%s" % (pkg_name, ver_str))
+		print('=> View pre-vetted package report at https://packj.dev/package/PyPi/{pkg_name}/{ver_str}')
 
 def get_base_pkg_info():
 	from options import Options
 	opts = Options(sys.argv[1:])
-	assert opts, "Failed to parse cmdline args!"
+	assert opts, 'Failed to parse cmdline args!'
 
 	args = opts.args()
-	assert args, "Failed to parse cmdline args!"
+	assert args, 'Failed to parse cmdline args!'
 
 	if args.debug:
 		import tempfile
 		_, filename = tempfile.mkstemp(suffix='.log')
-		print("*** Running in debug mode (log: %s) ***" % (filename))
+		print(f'*** Running in debug mode (log: {filename}) ***')
 		logging.basicConfig(filename=filename, datefmt='%H:%M:%S', level=logging.DEBUG,
 							format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s')
 	else:
@@ -640,9 +681,9 @@ def get_base_pkg_info():
 		return PackageManagerEnum.pypi, pm_name, args.pkg_name
 	if pm_name == 'npm':
 		return PackageManagerEnum.npmjs, pm_name, args.pkg_name
-	raise Exception("Package manager %s is not supported" % (pm_name))
+	raise Exception(f'Package manager {pm_name} is not supported')
 
-if __name__ == "__main__":
+if __name__ == '__main__':
 	try:
 		main(*get_base_pkg_info())
 	except Exception as e_main:

--- a/threats.csv
+++ b/threats.csv
@@ -17,7 +17,7 @@ suspicious,behaves differently across environments
 #
 # vulnerable to code exploits
 #
-vulnerable,contains known vulnerablities (CVEs)
+vulnerable,contains known vulnerabilities (CVEs)
 vulnerable,insecure network communication
 
 #


### PR DESCRIPTION
# Motivation

Initially I only wanted to provide a refactor for the long if-elif statement in `analyze_apis()`. However, when loading up my IDE I noticed a lot of python code convention violations as well as outdated/inconsistent usages of strings as well as dangerous default values for function arguments (dictionaries) and overpopulated function signatures. So I took my time with a superficial refactor of the whole `main.py` file.

# Purpose

The suggested changes should - imho - make `main.py` better maintainable by reducing code duplications and bring it more in line with python's pep8 standard. There should be no changes in how the file functions (except for a typo fix).

Tested against `python3 main.py pypi requests==2.18.4` on `Ubuntu 20.04.4 LTS` (WSL) with `python 3.8.10`).