### PR TITLE
Fix proc/self path exception

### DIFF
--- a/packj/util/job_util.py
+++ b/packj/util/job_util.py
@@ -49,14 +49,20 @@ def md5_digest_file(filepath):
 	import hashlib
 	return hashlib.md5(open(filepath,'rb').read()).hexdigest()
 
+def proc_path_exists():
+    return os.path.exists('/proc/self/mountinfo')
+
 def is_mounted(path):
-	with open('/proc/self/mountinfo') as file:
-		line = file.readline().strip()
-		while line:
-			if f'{ path }' in line:
-				return line.split()[3]
-			line = file.readline().strip()
-	return None
+    if proc_path_exists():
+        with open('/proc/self/mountinfo') as file:
+            line = file.readline().strip()
+            while line:
+                if f'{path}' in line:
+                    return line.split()[3]
+                line = file.readline().strip()
+        return None
+    else:
+        return None
 
 def in_podman():
 	return os.path.exists('/run/.containerenv')


### PR DESCRIPTION
During an audit run, the code for checking for docker:
```
with open('/proc/self/mountinfo') as file:
```
Can throw an exception and end the execution with the following error:
```
[Errno 2] No such file or directory: '/proc/self/mountinfo'
```

With this commit, we check if the path exists on the system, and if not, we skip the opening of the path for '/proc/self/mountinfo' and return None
