### PR TITLE
Fixed warning->warn for install on non-Linux, for audit without sandbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,9 @@ __pycache__
 # virtual env
 .env/
 .venv/
+
+# Python setuptools
+build/
+packj.egg-info/
+
+

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ class custom_install(install):
 			target_dir = os.path.realpath(self.build_lib)
 			setup_sandbox(target_dir)
 		except Exception as e:
-			distutils_logger.warning(f'Custom build failed: {str(e)}! Sandbox feature will not work')
+			distutils_logger.warn(f'Custom build failed: {str(e)}! Sandbox feature will not work')
 
 setup(
 	name = 'packj',


### PR DESCRIPTION
Fixes [issue 17](https://github.com/ossillate-inc/packj/issues/17).

Allows systems that don't support the sandbox to continue without installing it.

This patch:
* fixes the call on `:63`, changing `warning` to be `warn`
  * `distutils` still uses the (in other places deprecated) [original PEP-0282 name](https://peps.python.org/pep-0282/#loggers)
* adds 3 lines to `.gitignore` to ignore Python setuptools artifacts