### PR TITLE
Fix pip installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,19 +46,10 @@ View on GitHub [marketplace](https://packj.dev/go?next=https://github.com/market
 
 The quickest way to try/test Packj is using the PyPI package.
 
->
-> **Warning**: Packj only works on Linux.
->
+**Linux/Mac**: `pip3 install packj`
 
-```
-pip3 install packj
-```
+**Windows**: Install [WSL - Ubuntu](https://apps.microsoft.com/store/detail/ubuntu/9PDXGNCFSCZV). In WSL, run `sudo apt update;sudo apt install python3-pip;pip install pip --upgrade;pip install pyopenssl --upgrade`. Make sure to add `~/.local/bin` to your PATH. Now you can run the linux command above.
 
-Auditing RubyGems require additional dependencies
-
-```
-bundle install
-```
 
 ### 3. Docker image (recommended)
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ long_description = open(os.path.join(here, "README.md")).read()
 long_description_content_type = 'text/markdown'
 
 # this grabs the requirements from requirements.txt
-REQUIREMENTS = [i.strip().split('==')[0] for i in open(os.path.join(here, "requirements.txt")).readlines()]
+REQUIREMENTS = [i.strip() for i in open(os.path.join(here, "requirements.txt")).readlines()]
 
 def setup_sandbox(build_dir):
 	if sys.platform != 'linux':


### PR DESCRIPTION
This should fix https://github.com/ossillate-inc/packj/issues/6. Relevant: https://stackoverflow.com/questions/65326080/python-setup-config-install-requires-good-practices. I confirmed that packj `audit` and `auth` works with the pinned versions. 

It also adds directions for avoiding https://github.com/ossillate-inc/packj/issues/10