### PR TITLE
Improved Docker image build / sandbox setup process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,49 @@
+# syntax=docker/dockerfile:1
+
 FROM ubuntu:22.04
 
-RUN apt update -y --fix-missing
-RUN apt install -y --fix-missing python3 gcc python3-dev python3-pip ruby-full rubygems-integration musl-dev protobuf-compiler git ruby-full libmagic-dev strace curl autoconf build-essential libfreetype-dev libssl-dev gawk
-RUN gem install parser:3.0.0.0 google-protobuf:3.21.2 rubocop:1.31.1
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && apt-get install -y nodejs
+# Set up local user
+RUN groupadd -g 1001 ubuntu && \
+    useradd -rm -d /home/ubuntu -s /bin/bash -g ubuntu -u 1001 ubuntu
 
-RUN groupadd -g 1001 ubuntu
-RUN useradd -rm -d /home/ubuntu -s /bin/bash -g ubuntu -u 1001 ubuntu
+# Enable the apt downloaded packages cache, so we can hook it up to a Docker
+# BuildKit cache to speed up subsequent image builds.
+RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+# Add upstream Node.js apt repository
+ADD --chmod=755 https://deb.nodesource.com/setup_16.x /tmp/setup_16.x
+
+# Install OS (apt) dependencies
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    /tmp/setup_16.x && \
+    apt-get install --quiet --yes python3 gcc python3-dev python3-pip ruby-full rubygems-integration musl-dev protobuf-compiler git ruby-full libmagic-dev strace curl autoconf build-essential libfreetype-dev libssl-dev gawk nodejs
+
+# Install Ruby dependencies
+RUN --mount=type=cache,target=/root/.gem,sharing=locked \
+    gem install parser:3.0.0.0 google-protobuf:3.21.2 rubocop:1.31.1
+
+# Install pip dependencies
+COPY requirements.txt requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    pip3 install --upgrade --progress-bar off --disable-pip-version-check -r requirements.txt
+
+# Set up Packj sandbox tool
+COPY ./packj/sandbox /tmp/sandbox-install
+RUN cd /tmp/sandbox-install && \
+    ./install.sh -v && \
+    mv /tmp/sandbox-install/libsbox.so /tmp && \
+    rm -rf /tmp/sandbox-install
 
 WORKDIR /home/ubuntu/packj
 
 COPY --chown=ubuntu:ubuntu . .
-RUN pip3 install -r requirements.txt && cd packj/sandbox && ./install.sh && mkdir /home/ubuntu/.local /home/ubuntu/.ruby /home/ubuntu/.npm /home/ubuntu/.npm/_cacache && chown -R ubuntu:ubuntu /home/ubuntu
+RUN mv /tmp/libsbox.so /home/ubuntu/packj/packj/sandbox/libsbox.so
+
+RUN cd /home/ubuntu && \
+    mkdir .local ruby .npm .npm/_cacache && \
+    chown -R ubuntu:ubuntu /home/ubuntu
 
 USER ubuntu
 ENTRYPOINT ["python3", "main.py"]

--- a/packj/sandbox/install.sh
+++ b/packj/sandbox/install.sh
@@ -1,12 +1,39 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+IFS=$'\n\t'
+
 echo -n "Setting up Packj sandbox tool...."
 
 currdir=$(pwd)
-logfile=/tmp/strace.build.log
-tmpdir=/tmp/strace
+logfile=/tmp/packj-strace.build.log
+tmpdir=/tmp/packj-strace
+
+if [ "$1" == "-v" ]; then
+	verbose=true
+else
+	verbose=false
+fi
+
+run_command() {
+    if [ $verbose = true ]; then
+		$@ 2>&1
+	else
+		$@ >> $logfile 2>&1
+	fi
+}
+
+log() {
+	if [ $verbose = true ]; then
+		echo $@
+	else
+		echo $@ >> $logfile
+	fi
+}
 
 if [ ! -f $currdir/install.sh ]; then
 	echo "run this script from inside 'sandbox' dir."
-	exit
+	exit 1
 else
 	echo "may take up to 5 mins"
 fi
@@ -20,51 +47,51 @@ else
 	# remove stale installation
 	rm -rf $tmpdir
 
-	echo -n "	[+] Clonning strace..."
-	git clone -q --depth 1 --branch v5.19 -c advice.detachedHead=false https://github.com/strace/strace $tmpdir
+	echo -n "	[+] Cloning strace..."
+	run_command git clone --depth 1 --branch v5.19 -c advice.detachedHead=false https://github.com/strace/strace $tmpdir
 	if [ $? -ne 0 ]; then
 		echo "Failed"
-		exit
+		exit 1
 	else
 		echo "Done"
 	fi
 
 	cd $tmpdir
-	echo "===============================" >> $logfile
+	log "==============================="
 
 	# Bootstrap
 	echo -n "	[+] Unpacking strace (est: 2mins)..."
-	./bootstrap > $logfile 2>&1
-	if [ $? -ne 0 ]; then
-		rm -rf $tmpdir
-		echo "Failed [log: $logfile]"
-		exit
-	else
-		echo "Done"
-	fi
-
-	echo "===============================" >> $logfile
-
-	# Configure
-	echo -n "	[+] Configuring strace (est: 2mins)..."
-	CFLAGS='-fPIC' ./configure --enable-mpers=no --with-libselinux=no >> $logfile 2>&1
+    run_command "./bootstrap"
 	if [ $? -ne 0 ]; then
 		rm -rf $tmpdir
 		echo "Failed"
-		exit
+		exit 1
 	else
 		echo "Done"
 	fi
 
-	echo "===============================" >> $logfile
+	log "==============================="
+
+	# Configure
+	echo -n "	[+] Configuring strace (est: 2mins)..."
+	CFLAGS='-fPIC' run_command ./configure --enable-mpers=no --with-libselinux=no
+	if [ $? -ne 0 ]; then
+		rm -rf $tmpdir
+		echo "Failed"
+		exit 1
+	else
+		echo "Done"
+	fi
+
+	log "==============================="
 
 	# Make
 	echo -n "	[+] Compiling strace library..."
-	make -j4 >> $logfile 2>&1
+	run_command make -j4
 	if [ $? -ne 0 ]; then
 		rm -rf $tmpdir
 		echo "Failed to build strace"
-		exit
+		exit 1
 	else
 		echo "Done"
 	fi
@@ -72,17 +99,18 @@ else
 	# Final executable
 	echo -n "	[+] Creating strace executable..."
 	cd $tmpdir/src
-	gcc -fPIC -shared -o libstrace.so strace.c -DHAVE_CONFIG_H -Ilinux/x86_64/ libstrace_a-*.o gen/libstrace_a-gen_hdio.o
+	run_command gcc -fPIC -shared -o libstrace.so strace.c -DHAVE_CONFIG_H -Ilinux/x86_64/ libstrace_a-*.o gen/libstrace_a-gen_hdio.o
 	if [ $? -ne 0 ]; then
 		rm -rf $tmpdir
 		echo "Failed"
+		exit 1
 	else
 		cp libstrace.so $currdir/.
-		gcc strace.c -o strace -DHAVE_CONFIG_H -Ilinux/x86_64/ -L$tmpdir/src -lstrace -lrt
+		run_command gcc strace.c -o strace -DHAVE_CONFIG_H -Ilinux/x86_64/ -L$tmpdir/src -lstrace -lrt
 		if [ $? -ne 0 ]; then
 			rm -rf libstrace* $tmpdir
 			echo "Failed"
-			exit
+			exit 1
 		else
 			cp strace $currdir/.
 			echo "Done"
@@ -90,15 +118,16 @@ else
 	fi
 fi
 
-echo "===============================" >> $logfile
+log "==============================="
 
 echo -n "[+] Compiling sandbox library..."
 if [ ! -f $currdir/libsbox.so ]; then
 	cd $currdir
-	LIBSTRACE_PATH=. make >> $logfile 2>&1
+	LIBSTRACE_PATH=. run_command make
 	if [ $? -ne 0 ]; then
 		rm -rf $tmpdir
 		echo "Failed"
+		exit 1
 	else
 		echo "Done"
 	fi


### PR DESCRIPTION
I've been playing with Packj in a way that has necessitated a lot of Docker rebuilds. I eventually opted to try to speed the build process up a bit. These are the associated changes, if you are interested in taking them on.

- Dockerfile changes:
  - Changed step ordering to decrease number of step rebuilds required when common things (e.g. the codebase) change.
  - Replaced usage of the `apt` command-line too with `apt-get`. `apt` has an unstable interface and its authors recommend against using it in an automated fashion. 
  - Use Docker BuildKit caching for OS-level (apt), Python, and Ruby dependency installation steps.
  - Optimised Node.js installation process such that Node.js can be installed alongside the rest of the OS-level dependencies.
  - Only go through expensive / time-consuming sandbox setup process if the sandbox-related files have actually changed. If the codebase changes without the sandbox files changing, the previous sandbox setup persists.
- Sandbox setup (`setup.sh`) changes:
  - Added `set -uo pipefail` and `IFS=$'\n\t'` (['Unofficial bash strict mode'](http://redsymbol.net/articles/unofficial-bash-strict-mode/)) per bash practice for bash scripts. Note that `set -e` (usually part of strict mode) was not easily doable here (without changing how the script works). To minimise changes, I just excluded it, but it'd be nice to be able to use it at some point in the future.
  - Passing in the `-v` flag will print output that was previously just written to a log file. I added this to make the Docker image creation process more verbose, per best practice as you typically won't get access to log files written during the image build process.
  - Fixed typo ("Clonning" -> "Cloning").
  - Fixed some cases where the script would incorrectly return a zero exit status, which would incorrectly imply to Docker that the script had exited successfully, when it had in fact failed.